### PR TITLE
add SpoutLibrary.dll as a build dependency

### DIFF
--- a/addons/spout-gd/spout_gd.gdextension
+++ b/addons/spout-gd/spout_gd.gdextension
@@ -5,3 +5,11 @@ compatibility_minimum = 4.1
 [libraries]
 windows.debug.x86_64 = "res://addons/spout-gd/spout_gd.windows.template_debug.dll"
 windows.release.x86_64 = "res://addons/spout-gd/spout_gd.windows.template_release.dll"
+
+[dependencies]
+windows.release.x86_64 = {
+    "res://addons/spout-gd/SpoutLibrary.dll" : ""
+}
+windows.debug.x86_64 = {
+    "res://addons/spout-gd/SpoutLibrary.dll" : ""
+}


### PR DESCRIPTION
Currently exporting Animatron for Windows will not copy SpoutLibrary.dll into the same folder and Spout will not work. Adding the dependency will fix the issue.

Documentation on dependencies is scarce - this works but I am personally not quite sure what/why there are the empty strings here.

GitHub issue about missing documentation in Godot: https://github.com/godotengine/godot-docs/issues/9462
Redit thread with an example of dependencies that this solution is based on: https://www.reddit.com/r/godot/comments/17vii0e/gdextension_dependencies_section/